### PR TITLE
Add Questionnaire Identifier Support to Basic Form

### DIFF
--- a/client/app/form-builder/answer-lists.js
+++ b/client/app/form-builder/answer-lists.js
@@ -462,6 +462,28 @@ var answerLists = {
       "text": "10 thousand per microliter"
     }
   ],
+  "identifierUseCodes": [
+    {
+      "code": "usual",
+      "text": "Usual",
+    },
+    {
+      "code": "official",
+      "text": "Official",
+    },
+    {
+      "code": "temp",
+      "text": "Temp",
+    },
+    {
+      "code": "secondary",
+      "text": "Secondary",
+    },
+    {
+      "code": "old",
+      "text": "Old",
+    }
+  ],
   "statusCodes": [
     {
       "code": "draft",

--- a/client/app/form-builder/formlevel-panel/basic-form-level-fields-def.js
+++ b/client/app/form-builder/formlevel-panel/basic-form-level-fields-def.js
@@ -65,6 +65,87 @@ var basicFormLevelFieldsDef = {
       "linkId": "/status"
     },
     {
+      "questionCode": "identifier",
+      "localQuestionCode": "Coding",
+      "question": "Identifier",
+      "header": true,
+      "codingInstructions": "Typically, this is used for identifiers that can go in an HL7 V3 II (instance identifier) data type, and can then identify this questionnaire outside of FHIR, where it is not possible to use the logical URI.<br/><b>FHIR type: Identifier</b>",
+      "codingInstructionsFormat": "html",
+      "questionCardinality": {
+          "min": "0",
+          "max": "*"
+      },
+      "items": [
+          {
+              "questionCode": "system",
+              "localQuestionCode": "uri",
+              "question": "System",
+              "dataType": "URL",
+              "header": false,
+              "codingInstructions": "Identity of the terminology system.<br/><b>FHIR type: uri</b>",
+              "codingInstructionsFormat": "html",
+              "linkId": "/identifier/system"
+          },
+          {
+              "questionCode": "value",
+              "localQuestionCode": "string",
+              "question": "value",
+              "dataType": "ST",
+              "header": false,
+              "codingInstructions": "The value that is unique.<br/><b>FHIR type: string</b>",
+              "codingInstructionsFormat": "html",
+              "linkId": "/identifier/value"
+          },
+          {
+              "questionCode": "use",
+              "localQuestionCode": "code",
+              "question": "Use",
+              "dataType": "CNE",
+              "answers": "identifierUseCodes",
+              "header": false,
+              "codingInstructions": "Use: Usual | official | temp | secondary | old (If known)<br/><b>FHIR type: code</b>",
+              "codingInstructionsFormat": "html",
+              "linkId": "/identifier/use",
+              "defaultAnswer": {
+                  "text": "Usual",
+                  "code": "usual"
+              },
+          },
+          {
+              "questionCode": "period",
+              "localQuestionCode": "Period",
+              "question": "Identifier Period",
+              "header": true,
+              "codingInstructions": "Time period during which identifier is/was valid for use.<br/><b>FHIR type: Period</b>",
+              "codingInstructionsFormat": "html",
+              "items": [
+                  {
+                      "questionCode": "start",
+                      "localQuestionCode": "dateTime",
+                      "question": "Start",
+                      "dataType": "DTM",
+                      "header": false,
+                      "codingInstructions": "Starting time with inclusive boundary.<br/><b>FHIR type: dateTime</b>",
+                      "codingInstructionsFormat": "html",
+                      "linkId": "/identifier/period/start"
+                  },
+                  {
+                      "questionCode": "end",
+                      "localQuestionCode": "dateTime",
+                      "question": "End",
+                      "dataType": "DTM",
+                      "header": false,
+                      "codingInstructions": "End time with inclusive boundary, if not ongoing.<br/><b>FHIR type: dateTime</b>",
+                      "codingInstructionsFormat": "html",
+                      "linkId": "/identifier/period/end"
+                  }
+              ],
+              "linkId": "/identifier/period"
+          }
+      ],
+      "linkId": "/identifier"
+    },
+    {
       "questionCode": "url",
       "localQuestionCode": "uri",
       "question": "URL",


### PR DESCRIPTION
**Description:**
During the recent connectathon our team had the chance to evaluate your application and found that it would provide value to our team. However, it appears that the `Identifier` is not a property that can be auto-generated or added via the applications front end. 

In our case (and we imagine others) having an identifier would be a desirable feature. I am opening this PR in hopes that this small feature may be included in your application. 


  - Adding identifier to basic-form-level-fields-def.js and support the following properties
  - Identifier
  - Identifier.use
  - Identifier.value
  - Identifier.system
  - Identifier.period

  - Updated answer-lists.js to contain list of `Identifier.use` codes
  - Update does not include support for assigner or type as no example of any such property can be seen used in this code repo.