### PR TITLE
Fix startup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ environment. You can make a similar rc file to suit your shell. Please make sure
 path for the rest of the installation. 
 
         $ cd formbuilder-lhcforms
-        $ npm ci && npm run create-version-file
+        $ npm ci && npm run create-version-file && npm run copy-lforms
         $ source bashrc.formbuilder
         
 1. Start formbuilder server for development.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ace-builds": "^1.5.1",
     "autocomplete-lhc": "^18.1.3",
     "bootstrap": "^4.6.0",
+    "easy-path-expressions": "^3.1.0",
     "fast-copy": "^2.1.1",
     "fhirclient": "^2.3.11",
     "jexl": "^2.3.0",


### PR DESCRIPTION
1. Compilation fails due to missing `easy-path-expressions` dependency
![image](https://user-images.githubusercontent.com/109251240/221012147-21a406c4-895a-48d7-b50b-387cad442aae.png)
1. After adding the above dependency and executing `npm start`, the following errors are displayed in the browser console:
![image](https://user-images.githubusercontent.com/109251240/221012483-8130945a-6cc9-424e-a4a3-e8315a8158f3.png)
the README does not specify that the `npm run copy-lforms` command should be executed prior to `npm start`. 