### PR TITLE
added attachment for data type

### DIFF
--- a/src/assets/ngx-item.schema.json5
+++ b/src/assets/ngx-item.schema.json5
@@ -54,7 +54,7 @@
         "labelClasses": "col-2 ps-0 pe-1",
         "controlClasses": "col-10 p-0",
         "selectOptionsMap": {
-          "remove": ["reference", "attachment"],
+          "remove": ["reference"],
           "validateType": true
         }
       },


### PR DESCRIPTION
## Add support for FHIR Questionnaire attachment type

### Summary
This PR adds support for the `attachment` data type in the NLM Form Builder. Users can now add file upload fields to their questionnaires, allowing collection of files such as images, PDFs, and other documents.

### Key Features
- "Attachment" is now available in the Data type dropdown when editing items.
- Users can upload and download files (images, PDFs, JSON, etc.) in the rendered form and preview.